### PR TITLE
Fix the auto-sync action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@
 name: Sync Telliot docs
 on:
   schedule: 
-  - cron: "0 0 * * *" # every day. set to whatever interval you like
+  - cron: "0 */1 * * *" # every hour. set to whatever interval you like
 
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,5 @@
 # Sync Telliot docs from https://github.com/tellor-io/telliot/tree/master/docs in telliot-documentation folder in the current repo
 name: Sync Telliot docs
-
-on:
   schedule: 
   - cron: "0 0 * * *" # every 15 minutes. set to whatever interval you like
 
@@ -31,23 +29,15 @@ jobs:
           export CURRENT_MD5=$(find $GITHUB_WORKSPACE/telliot-documentation -type f -exec md5sum {} \; | md5sum | cut -d" " -f1)
           if [ "$TELLIOT_MD5" != "$CURRENT_MD5" ];
           then 
-            # Prepair remote SUMMARY.md file
-            # Remove unused heading
-            sed -i '/## /d' ./telliot/docs/SUMMARY.md
-            # Remove whitespace lines
-            sed -i -r '/^\s*$/d' ./telliot/docs/SUMMARY.md
-            # Update links
-            sed -i 's/(/(telliot-documentation\//g' ./telliot/docs/SUMMARY.md
-            python .github/workflow/update-summary.py ./telliot/docs/SUMMARY.md
-            # We don't need this information here
-            rm -f ./telliot/docs/SUMMARY.md
             # Let's update the content table
+            python .github/workflows/update-summary.py ./telliot/docs/
+            # Update telliot-documentation folder
             rm -rf $GITHUB_WORKSPACE/telliot-documentation
             mv ./telliot/docs $GITHUB_WORKSPACE/telliot-documentation
           fi
       - name: Clean up before PR
         run: |
           rm -rf ./telliot
-          rm -f SUMMARY.md.orig
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,8 @@
 # Sync Telliot docs from https://github.com/tellor-io/telliot/tree/master/docs in telliot-documentation folder in the current repo
 name: Sync Telliot docs
+on:
   schedule: 
-  - cron: "0 0 * * *" # every 15 minutes. set to whatever interval you like
+  - cron: "0 0 * * *" # every day. set to whatever interval you like
 
 
 jobs:

--- a/.github/workflows/update-summary.py
+++ b/.github/workflows/update-summary.py
@@ -16,6 +16,8 @@ fname = 'SUMMARY.md'
 with open(fname, 'r') as f:
    data = f.read()
 with open(fname, 'w') as fout:
+    if "## Telliot Documentation" not in data:
+        sys.exit("We expect a '## Telliot Documentation' heading in SUMMARY.md file, so we can update it's content!")
     data = re.sub(r'(## Telliot Documentation).*?(##)', 
       r'\1\n\n' +
       new_content + 

--- a/.github/workflows/update-summary.py
+++ b/.github/workflows/update-summary.py
@@ -8,9 +8,9 @@ def doc_to_index(doc_name):
 
 if len(sys.argv) < 2:
     sys.exit("USAGE: update-summary.py path/to/docs")
-docs = [os.path.basename(x) for x in sorted(glob.glob("%s/[!README]*.md"%sys.argv[1]))]
+docs = [os.path.basename(x) for x in sorted(glob.glob("%s/[!README|!CHANGELOG]*.md"%sys.argv[1]))]
 docs = map(lambda x: "* [%s](telliot-documentation/%s)" % (doc_to_index(x), x), docs)
-docs = ["* [Introduction](telliot-documentation/README.md)"] + docs
+docs = ["* [Introduction](telliot-documentation/README.md)"] + docs + ["* [Changelog](telliot-documentation/CHANGELOG.md)"]
 new_content = "\n".join(docs)
 fname = 'SUMMARY.md'
 with open(fname, 'r') as f:

--- a/.github/workflows/update-summary.py
+++ b/.github/workflows/update-summary.py
@@ -1,15 +1,23 @@
-import os, sys, re
+import os, sys, re, glob
+
+def doc_to_index(doc_name):
+    x = doc_name.split("_")[1]
+    x = x.lower().replace("-", " ")
+    x = x.capitalize()
+    return x.split(".")[0]
 
 if len(sys.argv) < 2:
-    sys.exit("USAGE: update-summary.py <path/to/INDEX.md>")
+    sys.exit("USAGE: update-summary.py path/to/docs")
+docs = [os.path.basename(x) for x in sorted(glob.glob("%s/[!README]*.md"%sys.argv[1]))]
+docs = map(lambda x: "* [%s](telliot-documentation/%s)" % (doc_to_index(x), x), docs)
+docs = ["* [Introduction](telliot-documentation/README.md)"] + docs
+new_content = "\n".join(docs)
 fname = 'SUMMARY.md'
-os.rename(fname, fname + '.orig')
-with open(fname + '.orig', 'r') as fin, open(fname, 'w') as fout, open(sys.argv[1], "r") as fcontent:
-    newContent = fcontent.read()
-    data = fin.read()
-
-    data = re.sub(r'(## Miner Documentation).*?(##)', 
+with open(fname, 'r') as f:
+   data = f.read()
+with open(fname, 'w') as fout:
+    data = re.sub(r'(## Telliot Documentation).*?(##)', 
       r'\1\n\n' +
-      newContent + 
+      new_content + 
       r'\2\n\n##', data, flags=re.DOTALL)
     fout.write(data)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -25,7 +25,7 @@
   * [Data Request IDs](dev-documentation/reference-page/data-request-ids.md)
   * [Variable Hashes](dev-documentation/reference-page/variable-hashes.md)
 
-## Miner Documentation
+## Telliot Documentation
 
 * [Become a Miner](miner-documentation/miner.md)
 * [The Guide](miner-documentation/the-guide.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -27,11 +27,16 @@
 
 ## Telliot Documentation
 
-* [Become a Miner](miner-documentation/miner.md)
-* [The Guide](miner-documentation/the-guide.md)
-* [Configuation](miner-documentation/configuation.md)
-* [Reference](miner-documentation/miner-reference.md)
-* [Disclaimer](miner-documentation/disclaimer.md)
+* [Introduction](telliot-documentation/README.md)
+* [Miner](telliot-documentation/01_miner.md)
+* [The guide](telliot-documentation/02_the-guide.md)
+* [Configuation](telliot-documentation/03_configuation.md)
+* [Contributing](telliot-documentation/04_contributing.md)
+* [Coding style guide](telliot-documentation/05_coding-style-guide.md)
+* [Miner reference](telliot-documentation/06_miner-reference.md)
+* [Release process](telliot-documentation/07_release-process.md)
+* [Disclaimer](telliot-documentation/08_disclaimer.md)
+* [Changelog](telliot-documentation/CHANGELOG.md)##
 
 ## Holder Documentation <a id="trb-token-holders"></a>
 


### PR DESCRIPTION
### How this action works
1. Compare the `telliot-documentation` folder in this repo with the `docs` folder in Telliot repo.
2. If differ -> 
+ update `telliot-documentation` file contents.
+ Update SUMMARY.md file
** This expect that document files in Telliot `docs` are sorted using file names similar to `05_coding-style-guide.md`. Then this naming leads to an entry of `* [Coding style guide](telliot-documentation/05_coding-style-guide.md)` in the `SUMMARY.md`.
** Also, `docs/README.md` from Telliot repo leads to an entry of `* [Introduction](telliot-documentation/README.md)`. 
3. Finally creates a PR like [this](https://github.com/hhio618/TellorDocs/pull/8).
### Refs
[telliot#268](https://github.com/tellor-io/telliot/issues/268)