### PR TITLE
fix: Update link to feeds on telliot-feeds repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Built for any [data type](https://tellor.io/blog/how-to-query-custom-data-with-t
 {% tabs %}
 {% tab title="I want a price feed" %}
 1. [Get a QueryID](getting-data/creating-a-query.md#getting-a-query-id-and-query-data)
-2. [Check if Telliot can currently report it](https://github.com/tellor-io/telliot-feeds/tree/main/src/telliot\_feed\_examples/feeds)
+2. [Check if Telliot can currently report it](https://github.com/tellor-io/telliot-feeds/tree/main/src/telliot\_feeds/feeds)
    * if yes, go to step 3
    * if no, [request a new spotPrice asset](https://github.com/tellor-io/dataSpecs/issues/24)
 3. [Get your data](broken-reference)

--- a/getting-data/introduction.md
+++ b/getting-data/introduction.md
@@ -39,7 +39,7 @@ Query ID Builder
 
 #### **Price data**
 
-First check if the data is already [being reported](https://github.com/tellor-io/telliot-feeds/tree/main/src/telliot\_feed\_examples/feeds) by viewing our [feeds](https://feed.tellor.io/).
+First check if the data is already [being reported](https://github.com/tellor-io/telliot-feeds/tree/main/src/telliot\_feeds/feeds) by viewing our [feeds](https://feed.tellor.io/).
 
 Tellor data is free for anyone to read. This means that if someone else just updated the value, you can use it free of charge! ****&#x20;
 


### PR DESCRIPTION
Hey all, noticed the link to currently supported feeds was broken in a couple places, so I fixed it.

* [Previous link (broken)](https://github.com/tellor-io/telliot-feeds/tree/main/src/telliot\_feed\_examples/feeds)
* [New link](https://github.com/tellor-io/telliot-feeds/tree/main/src/telliot\_feeds/feeds)